### PR TITLE
Corrigir os URLs das Imagens Enviadas

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -15,8 +15,10 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path, re_path, include
+from django.conf.urls.static import static
+from django.conf import settings
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     re_path('api/(?P<version>(v1|v2))/', include('app.urls'))
-]
+] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/app/urls.py
+++ b/app/urls.py
@@ -14,4 +14,4 @@ urlpatterns = [
          name="word-single"),
     path('Letter/<name>', RetrieveUpdateDestroyLetterView.as_view(),
          name="letter-single"),
-] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+]

--- a/app/urls.py
+++ b/app/urls.py
@@ -1,6 +1,4 @@
 from django.urls import path
-from django.conf import settings
-from django.conf.urls.static import static
 from .views import ListCreateWordView
 from .views import ListCreateLetterView
 from .views import RetrieveUpdateDestroyLetterView


### PR DESCRIPTION
# Corrigir os URLs das Imagens Enviadas

## Descrição 
Corrige as rotas estáticas para fornecer imagens

[Corrigir os URLs das Imagens Enviadas](#17)

## Porque este Pull Request é necessário?
Para que a API forneça as imagens corretamente

## Critérios de Aceitação
- [x] URL acessível

Resolve #17 
![](https://media.giphy.com/media/ABLoptl2pxcAg/source.gif)