### PR TITLE
Respostas das requisições estão paginadas

### DIFF
--- a/api/settings.py
+++ b/api/settings.py
@@ -132,7 +132,7 @@ MEDIA_URL = '/media/'
 REST_FRAMEWORK = {
     'DEFAULT_PAGINATION_CLASS': "rest_framework.pagination"
                                 + ".PageNumberPagination",
-    'PAGE_SIZE': 10
+    'PAGE_SIZE': 100
 }
 
 CORS_ORIGIN_WHITELIST = [


### PR DESCRIPTION
# Respostas das requisições estão paginadas

## Descrição 
Aumentando o tamanho limite da paginação da API

[Respostas das requisições estão sendo paginadas](#21)

## Porque este Pull Request é necessário?
Para  que as requisições funcionem corretamente 

## Critérios de Aceitação
- [x] Bug resolvido 

Resolve #21  

![](https://media.giphy.com/media/5iNhS5QCbSxnG/giphy.gif)